### PR TITLE
added `with Product with Serializable` this looks nicer, for instance…

### DIFF
--- a/src/main/scala/RomanDigit.scala
+++ b/src/main/scala/RomanDigit.scala
@@ -1,4 +1,4 @@
-sealed trait RomanDigit extends Ordered[RomanDigit] {
+sealed trait RomanDigit extends Ordered[RomanDigit] with Product with Serializable {
   def compare(that: RomanDigit) = {
     if (this == that) 0
     else if (this < that) 1


### PR DESCRIPTION
… in the REPL when we do List(I, V, X)