### PR TITLE
Remove sbt-bintray

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ converting back and forth from integers.
 Julius is published for Scala 2.13. To start using it add the following to your `build.sbt`:
 
 ```
-resolvers += Resolver.bintrayRepo("gn0s1s", "releases")
-
 libraryDependencies += "nl.gn0s1s" %% "julius" % "1.0.2"
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Julius - Roman Numerals
 
 ![build](https://github.com/Philippus/julius/workflows/build/badge.svg)
-[![codecov](https://codecov.io/gh/Philippus/julius/branch/master/graph/badge.svg)](https://codecov.io/gh/Philippus/julius)
+[![codecov](https://codecov.io/gh/Philippus/julius/branch/main/graph/badge.svg)](https://codecov.io/gh/Philippus/julius)
 ![Current Version](https://img.shields.io/badge/version-1.0.2-brightgreen.svg?style=flat "1.0.2")
 [![License](https://img.shields.io/badge/license-MIT-blue.svg?style=flat "MIT")](LICENSE.md)
 

--- a/build.sbt
+++ b/build.sbt
@@ -7,9 +7,6 @@ licenses += ("MIT", url("http://opensource.org/licenses/MIT"))
 
 scalaVersion := "2.13.5"
 
-bintrayOrganization := Some("gn0s1s")
-bintrayRepository := "releases"
-
 libraryDependencies ++= Seq(
   "org.scalacheck" %% "scalacheck" % "1.15.3" % Test
 )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,3 @@
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.3")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
-
-addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.6.1")


### PR DESCRIPTION
Applying this PR will remove sbt-bintray and Bintray related settings. On May 1st Bintray will be sunset (https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/). Next release will be published directly to Sonatype.